### PR TITLE
Fix: Mantis Button shows up when Printing / in Print Preview Issue

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,10 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@media print {
+  [id^="plasmo-overlay-"],
+  .plasmo-extension-container {
+    display: none !important;
+    visibility: hidden !important;
+  }
+}


### PR DESCRIPTION
 This PR updates global.css to hide the Mantis Button and extension container during printing and in print preview mode by using CSS media queries.
Fixes #15